### PR TITLE
Make `update_julia(1.1)` install 1.1, not 1.1x (e.g. 1.10)

### DIFF
--- a/src/UpdateJulia.jl
+++ b/src/UpdateJulia.jl
@@ -50,8 +50,16 @@ end
 is_stable(v::VersionNumber) = isempty(v.prerelease)
 is_nightly(v::VersionNumber) = v.prerelease == ("DEV",)
 
+function isconsistent(version, prefix)
+    startswith(version, prefix) || return false
+    # if the last digit of the prefix is a number and so is the next, then the number has
+    # been extended. This is bad and inconsistent (e.g. 1.1 is not 1.10).
+    0 < lastindex(prefix) < lastindex(version) || return true
+    return !(isdigit(version[lastindex(prefix)]) && isdigit(version[lastindex(prefix)+1]))
+end
+
 function latest(prefix="")
-    kys = collect(filter(v->startswith(string(v), prefix), keys(versions[])))
+    kys = collect(filter(v->isconsistent(string(v), prefix), keys(versions[])))
     isempty(kys) && throw(ArgumentError("No released versions starting with \"$prefix\""))
     partialsort!(kys, 1, lt=prefer)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,9 +38,19 @@ end
     @test UpdateJulia.prefer(v"1.7.0-rc1", missing)
 end
 
+@testset "isconsistent()" begin
+    @test !UpdateJulia.isconsistent("1.10.0-DEV.1729", "1.1")
+    @test UpdateJulia.isconsistent("1.10.0-DEV.1729", "1.10")
+    @test UpdateJulia.isconsistent("1.10.0-DEV.1729", "")
+    @test UpdateJulia.isconsistent("3.0.6", "3.0")
+    @test UpdateJulia.isconsistent("3.0.6", "3.0.6")
+    @test !UpdateJulia.isconsistent("3.0.62", "3.0.6")
+end
+
 @testset "latest()" begin
     @test UpdateJulia.latest() >= v"1.7.0"
     @test UpdateJulia.latest().prerelease == ()
+    @test UpdateJulia.latest("1.1") == v"1.1.1"
     @test UpdateJulia.latest("1.1.") == v"1.1.1"
     @test UpdateJulia.latest("1.5") == v"1.5.4"
     @test UpdateJulia.latest("1.2") == v"1.2.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,7 +169,7 @@ function random_matrix_test(n)
                 # If inexact, and cvs is a complete version string, don't match
                 try string(VersionNumber(cvs)) == cvs && return false catch end
                 # Otherwise match if prefix
-                UptadeJulia.isconsistent(xs, cvs)
+                UpdateJulia.isconsistent(xs, cvs)
             end
             actual = UpdateJulia.version_of(c)
             for i in installed

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,7 +169,7 @@ function random_matrix_test(n)
                 # If inexact, and cvs is a complete version string, don't match
                 try string(VersionNumber(cvs)) == cvs && return false catch end
                 # Otherwise match if prefix
-                startswith(xs, cvs)
+                UptadeJulia.isconsistent(xs, cvs)
             end
             actual = UpdateJulia.version_of(c)
             for i in installed


### PR DESCRIPTION
This predates the release of 1.9 so it's a bit early but tests are sensitive enough to start detecting this failure now that nightly is 1.10-DEV
