### PR TITLE
support very old julia versions slightly better

### DIFF
--- a/src/UpdateJulia.jl
+++ b/src/UpdateJulia.jl
@@ -166,6 +166,9 @@ function update_julia(version::AbstractString="";
     dry_run = false,
     verbose = dry_run)
 
+    install_location = expanduser(install_location) # Issue #23
+    bin = bin === nothing ? nothing : expanduser(bin)
+
     @static VERSION >= v"1.1" && verbose && display(Base.@locals)
     @static Sys.iswindows() && bin !== nothing && (println("bin not supported for windows"); bin=nothing)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,8 @@ function random_matrix_test(n)
                     push!(installed_versions, v_inst)
                 end
             catch x
-                if x isa ProcessFailedException && ((:migrate_packages => :force) ∈ kw || (:migrate_packages => true) ∈ kw)
+                if x isa (VERSION < v"1.2.0-rc1" ? ErrorException : ProcessFailedException) &&
+                        ((:migrate_packages => :force) ∈ kw || (:migrate_packages => true) ∈ kw)
                     v = UpdateJulia.latest(version)
                     if (v.major, v.minor) < (VERSION.major, VERSION.minor)
                         # Package migratoin requires Pkg at version to be compatible with

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,7 +105,7 @@ function random_matrix_test(n)
         # url => untested
         # aliases => untested
         # :systemwide => Bool, unfortunately, we can't do this trivially because userspace installs choose not to overwrite systemwide installs
-        :install_location => [mktempdir(), mktempdir(), "~/foo/bar"], # Tuple sampling is missing in julia 1.0
+        :install_location => [mktempdir(), mktempdir(), joionpath("~","foo1729","bar")], # Tuple sampling is missing in julia 1.0
         # bin => untested
         :dry_run => Bool,
         :verbose => Bool]
@@ -255,8 +255,6 @@ if ("CI" => "true") ∈ ENV
     # by masking julia-1.5
     @test update_julia("1.5", systemwide=true) == v"1.5.4"
 
-    mkdir("$(ENV["HOME"])/foo1729")
-    mkdir("$(ENV["HOME"])/foo1729/bar")
     random_matrix_test(4) # Small
     random_matrix_test(15) # Big
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,7 +247,7 @@ if ("CI" => "true") ∈ ENV
         # but still successfully sets julia-1.5.0
         @test UpdateJulia.version_of("julia-1.5.0") == v"1.5.0"
 
-        @test update_julia("1.8"; install_location="~/bin") >= v"1.8" # issue #23
+        @test update_julia("1.8"; install_location=joinpath("~","bin")) >= v"1.8" # issue #23
         @test Sys.isunix() ≠ isdir("~")
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,8 +94,6 @@ function random_matrix_test(n)
     versions = vcat(UpdateJulia.nightly_version[], filter!(collect(keys(UpdateJulia.versions[]))) do x
         x >= (Sys.iswindows() ? v"1.5.0-rc2" : v"1.0.0")
     end)
-    mkdir("$(ENV["HOME"])/foo")
-    mkdir("$(ENV["HOME"])/foo/bar")
     keywords = [
         # os_str => untested
         # arch => untested
@@ -254,6 +252,8 @@ if ("CI" => "true") ∈ ENV
     # by masking julia-1.5
     @test update_julia("1.5", systemwide=true) == v"1.5.4"
 
+    mkdir("$(ENV["HOME"])/foo1729")
+    mkdir("$(ENV["HOME"])/foo1729/bar")
     random_matrix_test(4) # Small
     random_matrix_test(15) # Big
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,7 +247,7 @@ if ("CI" => "true") ∈ ENV
         # but still successfully sets julia-1.5.0
         @test UpdateJulia.version_of("julia-1.5.0") == v"1.5.0"
 
-        @test update_julia("1.8"; bin="~/bin") >= v"1.8" # issue #23
+        @test update_julia("1.8"; install_location="~/bin") >= v"1.8" # issue #23
         @test Sys.isunix() ≠ isdir("~")
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,7 +105,7 @@ function random_matrix_test(n)
         # url => untested
         # aliases => untested
         # :systemwide => Bool, unfortunately, we can't do this trivially because userspace installs choose not to overwrite systemwide installs
-        :install_location => [mktempdir(), mktempdir(), joionpath("~","foo1729","bar")], # Tuple sampling is missing in julia 1.0
+        :install_location => [mktempdir(), mktempdir(), joinpath("~","foo1729","bar")], # Tuple sampling is missing in julia 1.0
         # bin => untested
         :dry_run => Bool,
         :verbose => Bool]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,8 @@ function random_matrix_test(n)
     versions = vcat(UpdateJulia.nightly_version[], filter!(collect(keys(UpdateJulia.versions[]))) do x
         x >= (Sys.iswindows() ? v"1.5.0-rc2" : v"1.0.0")
     end)
+    mkdir("$(ENV["HOME"])/foo")
+    mkdir("$(ENV["HOME"])/foo/bar")
     keywords = [
         # os_str => untested
         # arch => untested
@@ -105,7 +107,7 @@ function random_matrix_test(n)
         # url => untested
         # aliases => untested
         # :systemwide => Bool, unfortunately, we can't do this trivially because userspace installs choose not to overwrite systemwide installs
-        :install_location => [mktempdir(), mktempdir()], # Tuple sampling is missing in julia 1.0
+        :install_location => [mktempdir(), mktempdir(), "~/foo/bar"], # Tuple sampling is missing in julia 1.0
         # bin => untested
         :dry_run => Bool,
         :verbose => Bool]
@@ -150,6 +152,7 @@ function random_matrix_test(n)
 
 
     @testset "check" begin
+        @test !isdir("~")
         for c in commands
             cvs = c[7:end]
             installed = filter(installed_versions) do x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,7 +150,7 @@ function random_matrix_test(n)
 
 
     @testset "check" begin
-        @test !isdir("~")
+        @test !Sys.isunix() || !isdir("~")
         for c in commands
             cvs = c[7:end]
             installed = filter(installed_versions) do x
@@ -246,6 +246,9 @@ if ("CI" => "true") ∈ ENV
         )
         # but still successfully sets julia-1.5.0
         @test UpdateJulia.version_of("julia-1.5.0") == v"1.5.0"
+
+        @test update_julia("1.8"; bin="~/bin") >= v"1.8" # issue #23
+        @test Sys.isunix() ≠ isdir("~")
     end
 
     # Get proper 1.5 installed so we don't trigger false positives in the matrix


### PR DESCRIPTION
- add tilde expansion
- add tests
- only make dirs once and use more unique name
- update tests to account for the fact that this wont work on windows
- use install_location instead of bin in tests so that it works on windows
- try again with windows tests
- fixup
- fix typo
- support very old julia versions slightly better
