### PR TITLE
Deprecate UpdateJulia.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+# This package is no longer maintained.
+
+Please use [JuliaUp](https://github.com/JuliaLang/juliaup), a better Julia installer in most cases. See comparison below.
+
+## Comparison with alternatives
+
+&nbsp; | [UpdateJulia.jl](https://github.com/LilithHafner/UpdateJulia.jl) | [juliaup](https://github.com/JuliaLang/juliaup) | [jill](https://github.com/abelsiqueira/jill) | [Manual Installation](https://julialang.org/downloads/)
+--|--|--|--|--
+Official Julia Installer | :x: | :white_check_mark: | :x: | :white_check_mark:
+Can update to the latest version Julia without updating the installer | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+Can install Julia for the first time | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+Supports nightlies | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+Cross Platform | :white_check_mark: | :white_check_mark: | Linux Only | :white_check_mark:
+Can handle multiple versions | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark:
+No startup latency | :white_check_mark: | Negligible | :white_check_mark: | :white_check_mark:
+Available on the Windows Store | :x: | :white_check_mark: | :x: | :x:
+Installer Language | Julia | Rust | Shell | N/A
+How to install the installer | Julia's Pkg | Shell command | Shell command | N/A
+Maintained | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+Under active development | :x: | :white_check_mark: | :x: | :white_check_mark:
+Maintainers | :x: **Unmaintained!** | [@davidanthoff](https://github.com/davidanthoff) (with [JuliaLang](https://github.com/JuliaLang) as backup) | [@abelsiqueira](https://github.com/abelsiqueira) | [JuliaLang](https://github.com/JuliaLang)
+
 # UpdateJulia
 
 <!--[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://LilithHafner.github.io/UpdateJulia.jl/stable)-->
@@ -6,8 +28,6 @@
 [![Coverage](https://codecov.io/gh/LilithHafner/UpdateJulia.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/UpdateJulia.jl)
 
 ## Simple cross platform Julia installer
-
-Please also consider using [JuliaUp](https://github.com/JuliaLang/juliaup), especially for Windows. See comparison at the bottom of this file.
 
 Note: this is a Julia package that requires Julia 1.0 or higher to run. If you would like to install Julia and don't have at least Julia 1.0 installed already, please visit https://julialang.org/downloads.
 
@@ -115,20 +135,3 @@ Windows| `\Program Files`| automatically add install location to path| `~\AppDat
 
 \* Unix has somewhat loose conventions for install locations. If you already have Julia installed in a location that falls within those conventions, UpdateJulia will install the new version of Julia right next to the one you are currently using.
 
-## Comparison with alternatives
-
-&nbsp; | [UpdateJulia.jl](https://github.com/LilithHafner/UpdateJulia.jl) | [juliaup](https://github.com/JuliaLang/juliaup) | [jill](https://github.com/abelsiqueira/jill) | [Manual Installation](https://julialang.org/downloads/)
---|--|--|--|--
-Official Julia Installer | :x: | :white_check_mark: | :x: | :white_check_mark:
-Can update to the latest version Julia without updating the installer | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-Can install Julia for the first time | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-Supports nightlies | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark:
-Cross Platform | :white_check_mark: | :white_check_mark: | Linux Only | :white_check_mark:
-Can handle multiple versions | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark:
-No startup latency | :white_check_mark: | Negligible | :white_check_mark: | :white_check_mark:
-Available on the Windows Store | :x: | :white_check_mark: | :x: | :x:
-Installer Language | Julia | Rust | Shell | N/A
-How to install the installer | Julia's Pkg | Shell command | Shell command | N/A
-Maintained | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-Under active development | :x: | :white_check_mark: | :x: | :white_check_mark:
-Maintainers | [@LilithHafner](https://github.com/LilithHafner) | [@davidanthoff](https://github.com/davidanthoff) (with [JuliaLang](https://github.com/JuliaLang) as backup) | [@abelsiqueira](https://github.com/abelsiqueira) | [JuliaLang](https://github.com/JuliaLang)


### PR DESCRIPTION
With https://github.com/JuliaLang/juliaup/pull/809, juliaup has reached strict feature parity with UpdateJulia and I see no reason to continue maintaining UpdateJulia.jl

It was fun while it lasted and it was a quick and easy tool to develop and use while juliaup was still in it's early and non-cross-platform phase. 